### PR TITLE
[FLINK-20454] Suport reading Debezium metadata fields using `debezium-avro-confluent` format

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDeserializationSchema.MetadataConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.RowKind;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/** {@link DecodingFormat} for Debezium using Avro encoding. */
+public class DebeziumAvroDecodingFormat
+        implements ProjectableDecodingFormat<DeserializationSchema<RowData>> {
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    private List<String> metadataKeys;
+
+    // --------------------------------------------------------------------------------------------
+    // Debezium-specific attributes
+    // --------------------------------------------------------------------------------------------
+
+    private final String schemaRegistryURL;
+    private final String schema;
+    private final Map<String, ?> optionalPropertiesMap;
+
+    public DebeziumAvroDecodingFormat(
+            String schemaRegistryURL, String schema, Map<String, ?> optionalPropertiesMap) {
+        this.schemaRegistryURL = schemaRegistryURL;
+        this.schema = schema;
+        this.optionalPropertiesMap = optionalPropertiesMap;
+        this.metadataKeys = Collections.emptyList();
+    }
+
+    @Override
+    public DeserializationSchema<RowData> createRuntimeDecoder(
+            DynamicTableSource.Context context, DataType physicalDataType, int[][] projections) {
+        physicalDataType = Projection.of(projections).project(physicalDataType);
+
+        final List<ReadableMetadata> readableMetadata =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .collect(Collectors.toList());
+        final List<DataTypes.Field> metadataFields =
+                readableMetadata.stream()
+                        .map(m -> DataTypes.FIELD(m.key, m.dataType))
+                        .collect(Collectors.toList());
+
+        final DataType producedDataType =
+                DataTypeUtils.appendRowFields(physicalDataType, metadataFields);
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(producedDataType);
+
+        return new DebeziumAvroDeserializationSchema(
+                physicalDataType,
+                readableMetadata,
+                producedTypeInfo,
+                schemaRegistryURL,
+                schema,
+                optionalPropertiesMap);
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.put(m.key, m.dataType));
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys) {
+        this.metadataKeys = metadataKeys;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.UPDATE_BEFORE)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .addContainedKind(RowKind.DELETE)
+                .build();
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+
+    /** List of metadata that can be read with this format. */
+    enum ReadableMetadata {
+        INGESTION_TIMESTAMP(
+                "ingestion-timestamp",
+                DataTypes.TIMESTAMP(3).nullable(),
+                DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3)),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        return row;
+                    }
+                }),
+
+        SOURCE_TIMESTAMP(
+                "source.timestamp",
+                DataTypes.TIMESTAMP(3).nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("ts_ms");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_DATABASE(
+                "source.database",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("db");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_SCHEMA(
+                "source.schema",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("schema");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_TABLE(
+                "source.table",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("table");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_PROPERTIES(
+                "source.properties",
+                // key and value of the map are nullable to make handling easier in queries
+                DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable())
+                        .nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        Map<StringData, StringData> result = new HashMap<>();
+                        for (int i = 0; i < SOURCE_PROPERTY_FIELDS.length; i++) {
+                            Object value = row.getField(i);
+                            result.put(
+                                    StringData.fromString(SOURCE_PROPERTY_FIELDS[i].getName()),
+                                    value == null ? null : StringData.fromString(value.toString()));
+                        }
+                        return new GenericMapData(result);
+                    }
+                });
+
+        final String key;
+
+        final DataType dataType;
+
+        final DataTypes.Field requiredAvroField;
+
+        final MetadataConverter converter;
+
+        ReadableMetadata(
+                String key,
+                DataType dataType,
+                DataTypes.Field requiredAvroField,
+                MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.requiredAvroField = requiredAvroField;
+            this.converter = converter;
+        }
+    }
+
+    private static final DataTypes.Field[] SOURCE_PROPERTY_FIELDS = {
+        DataTypes.FIELD("version", DataTypes.STRING()),
+        DataTypes.FIELD("connector", DataTypes.STRING()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP(3).nullable()),
+        DataTypes.FIELD("snapshot", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("db", DataTypes.STRING()),
+        DataTypes.FIELD("sequence", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("schema", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("table", DataTypes.STRING()),
+        DataTypes.FIELD("txId", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("scn", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("commit_scn", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("lcr_position", DataTypes.STRING().nullable())
+    };
+    private static final Map<String, Integer> SOURCE_PROPERTY_POSITION =
+            IntStream.range(0, SOURCE_PROPERTY_FIELDS.length)
+                    .boxed()
+                    .collect(Collectors.toMap(i -> SOURCE_PROPERTY_FIELDS[i].getName(), i -> i));
+    private static final DataTypes.Field SOURCE_FIELD =
+            DataTypes.FIELD("source", DataTypes.ROW(SOURCE_PROPERTY_FIELDS));
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
@@ -21,18 +21,14 @@ package org.apache.flink.formats.avro.registry.confluent.debezium;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
-import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableFactory;
@@ -84,34 +80,7 @@ public class DebeziumAvroFormatFactory
         String schema = formatOptions.getOptional(SCHEMA).orElse(null);
         Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
 
-        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
-            @Override
-            public DeserializationSchema<RowData> createRuntimeDecoder(
-                    DynamicTableSource.Context context,
-                    DataType producedDataType,
-                    int[][] projections) {
-                producedDataType = Projection.of(projections).project(producedDataType);
-                final RowType rowType = (RowType) producedDataType.getLogicalType();
-                final TypeInformation<RowData> producedTypeInfo =
-                        context.createTypeInformation(producedDataType);
-                return new DebeziumAvroDeserializationSchema(
-                        rowType,
-                        producedTypeInfo,
-                        schemaRegistryURL,
-                        schema,
-                        optionalPropertiesMap);
-            }
-
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.newBuilder()
-                        .addContainedKind(RowKind.INSERT)
-                        .addContainedKind(RowKind.UPDATE_BEFORE)
-                        .addContainedKind(RowKind.UPDATE_AFTER)
-                        .addContainedKind(RowKind.DELETE)
-                        .build();
-            }
-        };
+        return new DebeziumAvroDecodingFormat(schemaRegistryURL, schema, optionalPropertiesMap);
     }
 
     @Override

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro.registry.confluent.debezium;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -32,14 +33,18 @@ import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContex
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -117,7 +122,7 @@ class DebeziumAvroFormatFactoryTest {
 
     private static final RowType ROW_TYPE =
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
-
+    private static final List<ReadableMetadata> REQUESTED_METADATA = Collections.emptyList();
     private static final String SUBJECT = "test-debezium-avro";
     private static final String REGISTRY_URL = "http://localhost:8081";
 
@@ -128,7 +133,8 @@ class DebeziumAvroFormatFactoryTest {
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE,
+                        fromLogicalToDataType(ROW_TYPE),
+                        REQUESTED_METADATA,
                         InternalTypeInfo.of(ROW_TYPE),
                         REGISTRY_URL,
                         null,
@@ -152,7 +158,8 @@ class DebeziumAvroFormatFactoryTest {
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE,
+                        fromLogicalToDataType(ROW_TYPE),
+                        REQUESTED_METADATA,
                         InternalTypeInfo.of(ROW_TYPE),
                         REGISTRY_URL,
                         AVRO_SCHEMA,
@@ -203,7 +210,7 @@ class DebeziumAvroFormatFactoryTest {
         assertThrows(IllegalArgumentException.class, () -> createSerializationSchema(options));
     }
 
-    @NotNull
+    @Nonnull
     private Map<String, String> getRegistryConfigs() {
         final Map<String, String> registryConfigs = new HashMap<>();
         registryConfigs.put("basic.auth.user.info", "something1");

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
 import org.apache.flink.formats.avro.RowDataToAvroConverters;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentSchemaRegistryCoder;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -77,7 +78,7 @@ class DebeziumAvroSerDeSchemaTest {
                                     FIELD("description", STRING()),
                                     FIELD("weight", DOUBLE()))
                             .getLogicalType();
-
+    private static final List<ReadableMetadata> requestedMetadata = Collections.emptyList();
     private static final Schema DEBEZIUM_SCHEMA_COMPATIBLE_TEST =
             new Schema.Parser().parse(new String(readBytesFromFile("debezium-test-schema.json")));
 
@@ -88,7 +89,7 @@ class DebeziumAvroSerDeSchemaTest {
 
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
-                        fromLogicalToDataType(rowType));
+                        fromLogicalToDataType(rowType), requestedMetadata);
         RowType rowTypeSe =
                 DebeziumAvroSerializationSchema.createDebeziumAvroRowType(
                         fromLogicalToDataType(rowType));
@@ -149,7 +150,7 @@ class DebeziumAvroSerDeSchemaTest {
     public List<String> testDeserialization(String dataPath) throws Exception {
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
-                        fromLogicalToDataType(rowType));
+                        fromLogicalToDataType(rowType), requestedMetadata);
 
         client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, 1, 81);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
